### PR TITLE
Fix Hue area motion sensors state handling

### DIFF
--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -13,6 +13,7 @@ from aiohue.v2.controllers.events import EventType
 from aiohue.v2.controllers.sensors import (
     CameraMotionController,
     ContactController,
+    ConvenienceAreaMotionController,
     GroupedMotionController,
     MotionController,
     SecurityAreaMotionController,
@@ -20,6 +21,7 @@ from aiohue.v2.controllers.sensors import (
 )
 from aiohue.v2.models.camera_motion import CameraMotion
 from aiohue.v2.models.contact import Contact, ContactState
+from aiohue.v2.models.convenience_area_motion import ConvenienceAreaMotion
 from aiohue.v2.models.entertainment_configuration import EntertainmentStatus
 from aiohue.v2.models.grouped_motion import GroupedMotion
 from aiohue.v2.models.motion import Motion
@@ -49,6 +51,7 @@ type SensorType = (
     | Tamper
     | GroupedMotion
     | SecurityAreaMotion
+    | ConvenienceAreaMotion
 )
 type ControllerType = (
     CameraMotionController
@@ -58,6 +61,7 @@ type ControllerType = (
     | TamperController
     | GroupedMotionController
     | SecurityAreaMotionController
+    | ConvenienceAreaMotionController
 )
 
 
@@ -124,6 +128,7 @@ async def async_setup_entry(
     register_items(api.sensors.tamper, HueTamperSensor)
     register_items(api.sensors.grouped_motion, HueGroupedMotionSensor)
     register_items(api.sensors.security_area_motion, HueMotionAwareSensor)
+    register_items(api.sensors.convenience_area_motion, HueConvenienceAreaMotionSensor)
 
 
 # pylint: disable-next=hass-enforce-class-module
@@ -149,7 +154,34 @@ class HueMotionSensor(HueBaseEntity, BinarySensorEntity):
 
 
 # pylint: disable-next=hass-enforce-class-module
-class HueGroupedMotionSensor(HueMotionSensor):
+class HueAreaMotionSensor(HueBaseEntity, BinarySensorEntity):
+    """Representation of a Hue area-based motion sensor."""
+
+    controller: (
+        GroupedMotionController
+        | SecurityAreaMotionController
+        | ConvenienceAreaMotionController
+    )
+    resource: GroupedMotion | SecurityAreaMotion | ConvenienceAreaMotion
+
+    entity_description = BinarySensorEntityDescription(
+        key="motion_sensor",
+        device_class=BinarySensorDeviceClass.MOTION,
+        has_entity_name=True,
+    )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        if not (motion_feature := self.resource.motion):
+            return None
+        if motion_feature.motion_report is not None:
+            return motion_feature.motion_report.motion
+        return motion_feature.motion
+
+
+# pylint: disable-next=hass-enforce-class-module
+class HueGroupedMotionSensor(HueAreaMotionSensor):
     """Representation of a Hue Grouped Motion sensor."""
 
     controller: GroupedMotionController
@@ -172,18 +204,11 @@ class HueGroupedMotionSensor(HueMotionSensor):
 
 
 # pylint: disable-next=hass-enforce-class-module
-class HueMotionAwareSensor(HueMotionSensor):
-    """Representation of a Motion sensor based on Hue Motion Aware.
+class HueMotionAreaConfigurationSensor(HueAreaMotionSensor):
+    """Base class for motion sensors linked to a motion area configuration."""
 
-    Note that we only create sensors for the SecurityAreaMotion resource
-    and not for the ConvenienceAreaMotion resource, because the latter
-    does not have a state when it's not directly controlling lights.
-    The SecurityAreaMotion resource is always available with a state, allowing
-    Home Assistant users to actually use it as a motion sensor in their HA automations.
-    """
-
-    controller: SecurityAreaMotionController
-    resource: SecurityAreaMotion
+    controller: SecurityAreaMotionController | ConvenienceAreaMotionController
+    resource: SecurityAreaMotion | ConvenienceAreaMotion
 
     entity_description = BinarySensorEntityDescription(
         key="motion_sensor",
@@ -191,20 +216,14 @@ class HueMotionAwareSensor(HueMotionSensor):
         has_entity_name=False,
     )
 
-    @property
-    def name(self) -> str:
-        """Return sensor name."""
-        return self.controller.get_motion_area_configuration(self.resource.id).name
-
     def __init__(
         self,
         bridge: HueBridge,
-        controller: SecurityAreaMotionController,
-        resource: SecurityAreaMotion,
+        controller: SecurityAreaMotionController | ConvenienceAreaMotionController,
+        resource: SecurityAreaMotion | ConvenienceAreaMotion,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(bridge, controller, resource)
-        # link the MotionAware sensor to the group the sensor is associated with
         self._motion_area_configuration = self.controller.get_motion_area_configuration(
             resource.id
         )
@@ -217,12 +236,37 @@ class HueMotionAwareSensor(HueMotionSensor):
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
         await super().async_added_to_hass()
-        # subscribe to updates of the MotionAreaConfiguration to update the name
         self.async_on_remove(
             self.bridge.api.config.subscribe(
                 self._handle_event, self._motion_area_configuration.id
             )
         )
+
+
+# pylint: disable-next=hass-enforce-class-module
+class HueMotionAwareSensor(HueMotionAreaConfigurationSensor):
+    """Representation of a Motion sensor based on Hue Motion Aware."""
+
+    controller: SecurityAreaMotionController
+    resource: SecurityAreaMotion
+
+    @property
+    def name(self) -> str:
+        """Return sensor name."""
+        return self._motion_area_configuration.name
+
+
+# pylint: disable-next=hass-enforce-class-module
+class HueConvenienceAreaMotionSensor(HueMotionAreaConfigurationSensor):
+    """Representation of a Hue Convenience Area Motion sensor."""
+
+    controller: ConvenienceAreaMotionController
+    resource: ConvenienceAreaMotion
+
+    @property
+    def name(self) -> str:
+        """Return sensor name."""
+        return f"{self._motion_area_configuration.name} Convenience Motion"
 
 
 # pylint: disable-next=hass-enforce-class-module

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -94,6 +94,13 @@ async def test_binary_sensors(
     assert sensor.name == "Motion Aware Sensor 1"
     assert sensor.attributes["device_class"] == "motion"
 
+    # test convenience area motion sensor
+    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
+    assert sensor is not None
+    assert sensor.state == "off"
+    assert sensor.name == "Motion Aware Sensor 1 Convenience Motion"
+    assert sensor.attributes["device_class"] == "motion"
+
 
 async def test_binary_sensor_add_update(
     hass: HomeAssistant, mock_bridge_v2: Mock
@@ -151,7 +158,7 @@ async def test_grouped_motion_sensor(
     sensor = hass.states.get("binary_sensor.sensor_group_motion")
     assert sensor.state == "on"
 
-    # test disabled grouped motion sensor == state unknown
+    # test disabled grouped motion sensor keeps last known state
     disabled_sensor = {
         "id": "2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e",
         "type": "grouped_motion",
@@ -160,7 +167,7 @@ async def test_grouped_motion_sensor(
     mock_bridge_v2.api.emit_event("update", disabled_sensor)
     await hass.async_block_till_done()
     sensor = hass.states.get("binary_sensor.sensor_group_motion")
-    assert sensor.state == "unknown"
+    assert sensor.state == "off"
 
 
 async def test_motion_aware_sensor(
@@ -204,3 +211,42 @@ async def test_motion_aware_sensor(
     sensor = hass.states.get("binary_sensor.motion_aware_sensor_1")
     assert sensor is not None
     assert sensor.name == "Updated Motion Area"
+
+
+async def test_convenience_area_motion_sensor(
+    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+) -> None:
+    """Test HueConvenienceAreaMotionSensor functionality."""
+
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
+
+    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
+    assert sensor is not None
+    assert sensor.state == "off"
+    assert sensor.attributes["device_class"] == "motion"
+
+    updated_sensor = {
+        "id": "4f317b69-9da0-4b4f-84f2-7ca07b9fe345",
+        "type": "convenience_area_motion",
+        "motion": {
+            "motion": True,
+            "motion_valid": True,
+            "motion_report": {"changed": "2023-09-23T08:13:42.394Z", "motion": True},
+        },
+    }
+    mock_bridge_v2.api.emit_event("update", updated_sensor)
+    await hass.async_block_till_done()
+    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
+    assert sensor.state == "on"
+
+    updated_config = {
+        "id": "5e6f7a8b-9c1d-4e2f-b3a4-5c6d7e8f9a0b",
+        "type": "motion_area_configuration",
+        "name": "Updated Motion Area",
+    }
+    mock_bridge_v2.api.emit_event("update", updated_config)
+    await hass.async_block_till_done()
+    sensor = hass.states.get("binary_sensor.motion_aware_sensor_1_convenience_motion")
+    assert sensor is not None
+    assert sensor.name == "Updated Motion Area Convenience Motion"


### PR DESCRIPTION
## Summary
- add support for Hue convenience area motion resources and unify area-motion state handling on the motion_report value
- expose motion area sensors with stable names tied to their configuration and keep grouped sensors linked to their parent group
- extend Hue binary sensor tests to cover convenience area motion sensors and updated grouped motion behaviour

## Testing
- pytest tests/components/hue/test_binary_sensor.py *(fails: Python 3.12 cannot parse PEP 695-style type parameter defaults in homeassistant/util/event_type.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d7969ff530832abf318fda69a6e189